### PR TITLE
Rename tweaks

### DIFF
--- a/src/Editor/SaveLevelState.cs
+++ b/src/Editor/SaveLevelState.cs
@@ -84,7 +84,7 @@ public class SaveLevelState
 
     private void drawNameBox(SpriteBatch sprBatch)
     {
-        _levelNameBox.x = (sprBatch.GraphicsDevice.Viewport.Bounds.Width / 2) - (_levelNameBox.Width / 2);
+        _levelNameBox.x = (sprBatch.GraphicsDevice.Viewport.Bounds.Width / 2) - (_levelNameBox.width / 2);
         _levelNameBox.y = (sprBatch.GraphicsDevice.Viewport.Bounds.Height / 2) - (UI.TextBox.Height / 2);
         _levelNameBox.Draw(sprBatch);
     }

--- a/src/Editor/SaveLevelState.cs
+++ b/src/Editor/SaveLevelState.cs
@@ -60,12 +60,12 @@ public class SaveLevelState
 
         if (!_saved)
         {
-            _saveButton.disabled = _levelNameBox.Text == "";
+            _saveButton.disabled = _levelNameBox.text == "";
             _saveButton.Update(mouse, mouseOld, kb, kbOld);
 
             if (_saveButton.IsClicked)
             {
-                BoardSaver.SaveBoard(board, _levelNameBox.Text, maxHints);
+                BoardSaver.SaveBoard(board, _levelNameBox.text, maxHints);
                 _saved = true;
             }
 
@@ -84,7 +84,7 @@ public class SaveLevelState
 
     private void drawNameBox(SpriteBatch sprBatch)
     {
-        _levelNameBox.x = (sprBatch.GraphicsDevice.Viewport.Bounds.Width / 2) - (_levelNameBox.width / 2);
+        _levelNameBox.x = (sprBatch.GraphicsDevice.Viewport.Bounds.Width / 2) - (_levelNameBox.Width / 2);
         _levelNameBox.y = (sprBatch.GraphicsDevice.Viewport.Bounds.Height / 2) - (UI.TextBox.Height / 2);
         _levelNameBox.Draw(sprBatch);
     }

--- a/src/LevelSelect.cs
+++ b/src/LevelSelect.cs
@@ -234,6 +234,7 @@ public class LevelSelect : IGameState
                         _modifyLevelName = _levels[i].Item1.name;
                         _renameLevel = true;
                         _renameBox.text = _modifyLevelName;
+                        _renameOKButton.disabled = true;
                     }
                 }
             }
@@ -253,6 +254,9 @@ public class LevelSelect : IGameState
         if (_renameLevel)
         {
             _renameBox.UpdateInput(tiea);
+
+            // disable if new name either same as old name or empty
+            _renameOKButton.disabled = _renameBox.text == _modifyLevelName || string.IsNullOrWhiteSpace(_renameBox.text);
         }
     }
 

--- a/src/LevelSelect.cs
+++ b/src/LevelSelect.cs
@@ -323,7 +323,8 @@ public class LevelSelect : IGameState
     private void doRename()
     {
         _renameLevel = false;
-        File.Move(Path.Combine(BoardSaver.GetLevelSavePath(), $"{_modifyLevelName}.nono"), Path.Combine(BoardSaver.GetLevelSavePath(), $"{_renameBox.text}.nono"));
+        string trimmedNewName = _renameBox.text.Trim();
+        File.Move(Path.Combine(BoardSaver.GetLevelSavePath(), $"{_modifyLevelName}.nono"), Path.Combine(BoardSaver.GetLevelSavePath(), $"{trimmedNewName}.nono"));
         FindLevels();
     }
 

--- a/src/LevelSelect.cs
+++ b/src/LevelSelect.cs
@@ -318,7 +318,7 @@ public class LevelSelect : IGameState
     private void doRename()
     {
         _renameLevel = false;
-        File.Move(Path.Combine(BoardSaver.GetLevelSavePath(), $"{_modifyLevelName}.nono"), Path.Combine(BoardSaver.GetLevelSavePath(), $"{_renameBox.Text}.nono"));
+        File.Move(Path.Combine(BoardSaver.GetLevelSavePath(), $"{_modifyLevelName}.nono"), Path.Combine(BoardSaver.GetLevelSavePath(), $"{_renameBox.text}.nono"));
         FindLevels();
     }
 

--- a/src/LevelSelect.cs
+++ b/src/LevelSelect.cs
@@ -233,6 +233,7 @@ public class LevelSelect : IGameState
                     {
                         _modifyLevelName = _levels[i].Item1.name;
                         _renameLevel = true;
+                        _renameBox.text = _modifyLevelName;
                     }
                 }
             }

--- a/src/UI/NumberTextBox.cs
+++ b/src/UI/NumberTextBox.cs
@@ -43,7 +43,7 @@ public class NumberTextBox : TextBox
 
     public int GetNumberValue()
     {
-        if (!int.TryParse(Text, out int number))
+        if (!int.TryParse(text, out int number))
             return -1;
         return number;
     }
@@ -57,9 +57,6 @@ public class NumberTextBox : TextBox
     private void checkMax()
     {
         if (_hasMax && GetNumberValue() > _max)
-        {
             BackSpace();
-            illegalBlink = true;
-        }
     }
 }

--- a/src/UI/TextBox.cs
+++ b/src/UI/TextBox.cs
@@ -9,7 +9,7 @@ public class TextBox : UIElement
 {
     public static readonly int Height = 30;
 
-    public string text { get; private set; }
+    public string text;
     public bool Hovered { get; private set; }
 
     public int width;

--- a/src/UI/TextBox.cs
+++ b/src/UI/TextBox.cs
@@ -9,7 +9,7 @@ public class TextBox : UIElement
 {
     public static readonly int Height = 30;
 
-    public string Text { get; private set; }
+    public string text { get; private set; }
     public bool Hovered { get; private set; }
 
     public int width;
@@ -33,7 +33,7 @@ public class TextBox : UIElement
         Color textColorHover, int maxLength = 0) : base(x, y)
     {
         this.width = width;
-        Text = "";
+        text = "";
         Hovered = false;
         illegalChars = new();
         _fillColor = fillColor;
@@ -98,7 +98,7 @@ public class TextBox : UIElement
                         if (illegalChars.Contains(tiea.Character))
                             illegalBlink = true;
                         else
-                            Text += tiea.Character;
+                            text += tiea.Character;
                     else
                         illegalBlink = true;
                     break;
@@ -108,9 +108,9 @@ public class TextBox : UIElement
 
     public bool BackSpace()
     {
-        if (Text.Length > 0)
+        if (text.Length > 0)
         {
-            Text = Text[..^1];
+            text = text[..^1];
             return true;
         }
         return false;
@@ -118,7 +118,7 @@ public class TextBox : UIElement
 
     public void Clear()
     {
-        Text = "";
+        text = "";
     }
 
     private Rectangle getRect()
@@ -130,7 +130,7 @@ public class TextBox : UIElement
     {
         Color textColor = Hovered ? _textColorHover : _textColor;
         Color placeholderColor = Hovered ? _placeholderColorHover : _placeholderColor;
-        Vector2 textSize = TextRenderer.MeasureString("DefaultFont", Text);
+        Vector2 textSize = TextRenderer.MeasureString("DefaultFont", text);
         float textWidth = textSize.X * 0.5f;
         float maxTextWidth = width - 17;
         float offset = 0;
@@ -146,10 +146,10 @@ public class TextBox : UIElement
         };
         sprBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, null, null, rs);
         sprBatch.GraphicsDevice.ScissorRectangle = getRect();
-        if (string.IsNullOrEmpty(Text) && !string.IsNullOrEmpty(_placeholder))
+        if (string.IsNullOrEmpty(text) && !string.IsNullOrEmpty(_placeholder))
             TextRenderer.DrawText(sprBatch, "DefaultFont", x + 4 - (int)offset, y, 0.5f, _placeholder, placeholderColor);
         else
-            TextRenderer.DrawText(sprBatch, "DefaultFont", x + 4 - (int)offset, y, 0.5f, Text + ((_blinkCursor && Hovered) ? "_" : ""), textColor);
+            TextRenderer.DrawText(sprBatch, "DefaultFont", x + 4 - (int)offset, y, 0.5f, text + ((_blinkCursor && Hovered) ? "_" : ""), textColor);
         sprBatch.End();
 
         sprBatch.Begin();
@@ -170,6 +170,6 @@ public class TextBox : UIElement
 
     private bool checkLength()
     {
-        return maxLength == 0 || (Text.Length + 1) < maxLength;
+        return maxLength == 0 || (text.Length + 1) < maxLength;
     }
 }


### PR DESCRIPTION
List of tweaks to the rename functionality:
- Rename box's text is set to the level name at the start
- The OK button is disabled if the level name is unchanged or is entirely whitespace
- The new name is trimmed before renaming (gets rid of whitespace at the beginning and end of the level name)